### PR TITLE
Use tar.gz file to download and extract

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,6 +6,7 @@ on:
       - 'master'
   push:
     branches:
+      - 'feature/*'
       - 'feature_*'
       - 'master'
   schedule:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Available variables are listed below (located in `defaults/main.yml`):
 awsnuke_app: aws-nuke
 awsnuke_version: 2.15.0
 awsnuke_osarch: linux-amd64
-awsnuke_dl_url: https://github.com/rebuy-de/{{ awsnuke_app }}/releases/download/v{{ awsnuke_version }}/{{ awsnuke_app }}-v{{ awsnuke_version }}-{{ awsnuke_osarch }}
+awsnuke_dl_url: https://github.com/rebuy-de/{{ awsnuke_app }}/releases/download/v{{ awsnuke_version }}/{{ awsnuke_app }}-v{{ awsnuke_version }}-{{ awsnuke_osarch }}.tar.gz
+awsnuke_app_owner: root
+awsnuke_app_group: root
 awsnuke_bin_path: /usr/local/bin
 awsnuke_file_mode: '0755'
 awsnuke_config_dir: "/etc/{{ awsnuke_app }}"
@@ -34,23 +36,25 @@ awsnuke_template_dest_group: root
 
 ### Variables table:
 
-Variable                    | Value (default)                                                                                                                                        | Description
---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------
-awsnuke_app                 | aws-nuke                                                                                                                                               | Defines the app to install i.e. **aws-nuke**
-awsnuke_version             | 2.15.0                                                                                                                                                 | Defined to dynamically fetch the desired version to install. Defaults to: **2.15.0**
-awsnuke_osarch              | linux-amd64                                                                                                                                            | Defines os architecture. Used for obtaining the correct type of binaries based on OS System Architecture. Defaults to: **linux-amd64**
-awsnuke_dl_url              | <https://github.com/rebuy-de/{{> awsnuke_app }}/releases/download/v{{ awsnuke_version }}/{{ awsnuke_app }}-v{{ awsnuke_version }}-{{ awsnuke_osarch }} | Defines URL to download the awsnuke binary from.
-awsnuke_bin_path            | /usr/local/bin                                                                                                                                         | Defined to dynamically set the appropriate path to store awsnuke binary into. Defaults to (as generally available on any user's PATH): **/usr/local/bin**
-awsnuke_file_mode           | '0755'                                                                                                                                                 | Mode for the binary file of aws-nuke.
-awsnuke_config_dir          | "/etc/{{ awsnuke_app }}"                                                                                                                               | Defined to create directory to store aws-nuke config file in.
-awsnuke_config_dir_mode     | '0744'                                                                                                                                                 | Permissions for aws-nuke config directory.
-awsnuke_config_dir_owner    | root                                                                                                                                                   | Owner of aws-nuke config directory.
-awsnuke_config_dir_group    | root                                                                                                                                                   | Group of aws-nuke config directory.
-awsnuke_template_source     | aws-nuke-config.yml.j2                                                                                                                                 | Source config template file to utilize.
-awsnuke_template_dest       | aws-nuke-config.yml                                                                                                                                    | Filename as to be placed in the configuration directory as for aws-nuke.
-awsnuke_template_dest_mode  | '0744'                                                                                                                                                 | Permission of aws-nuke configuration file.
-awsnuke_template_dest_owner | root                                                                                                                                                   | Owner of aws-nuke configuration file.
-awsnuke_template_dest_group | root                                                                                                                                                   | Group of aws-nuke configuration file.
+Variable                    | Value (default)                                                                                                                                               | Description
+--------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------
+awsnuke_app                 | aws-nuke                                                                                                                                                      | Defines the app to install i.e. **aws-nuke**
+awsnuke_version             | 2.15.0                                                                                                                                                        | Defined to dynamically fetch the desired version to install. Defaults to: **2.15.0**
+awsnuke_osarch              | linux-amd64                                                                                                                                                   | Defines os architecture. Used for obtaining the correct type of binaries based on OS System Architecture. Defaults to: **linux-amd64**
+awsnuke_dl_url              | <https://github.com/rebuy-de/{{> awsnuke_app }}/releases/download/v{{ awsnuke_version }}/{{ awsnuke_app }}-v{{ awsnuke_version }}-{{ awsnuke_osarch }}.tar.gz | Defines URL to download the awsnuke binary from.
+awsnuke_config_dir_owner    | root                                                                                                                                                          | Owner of aws-nuke binary file.
+awsnuke_config_dir_group    | root                                                                                                                                                          | Group of aws-nuke binary file.
+awsnuke_bin_path            | /usr/local/bin                                                                                                                                                | Defined to dynamically set the appropriate path to store awsnuke binary into. Defaults to (as generally available on any user's PATH): **/usr/local/bin**
+awsnuke_file_mode           | '0755'                                                                                                                                                        | Mode for the binary file of aws-nuke.
+awsnuke_config_dir          | "/etc/{{ awsnuke_app }}"                                                                                                                                      | Defined to create directory to store aws-nuke config file in.
+awsnuke_config_dir_mode     | '0744'                                                                                                                                                        | Permissions for aws-nuke config directory.
+awsnuke_config_dir_owner    | root                                                                                                                                                          | Owner of aws-nuke config directory.
+awsnuke_config_dir_group    | root                                                                                                                                                          | Group of aws-nuke config directory.
+awsnuke_template_source     | aws-nuke-config.yml.j2                                                                                                                                        | Source config template file to utilize.
+awsnuke_template_dest       | aws-nuke-config.yml                                                                                                                                           | Filename as to be placed in the configuration directory as for aws-nuke.
+awsnuke_template_dest_mode  | '0744'                                                                                                                                                        | Permission of aws-nuke configuration file.
+awsnuke_template_dest_owner | root                                                                                                                                                          | Owner of aws-nuke configuration file.
+awsnuke_template_dest_group | root                                                                                                                                                          | Group of aws-nuke configuration file.
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,9 @@
 awsnuke_app: aws-nuke
 awsnuke_version: 2.15.0
 awsnuke_osarch: linux-amd64
-awsnuke_dl_url: https://github.com/rebuy-de/{{ awsnuke_app }}/releases/download/v{{ awsnuke_version }}/{{ awsnuke_app }}-v{{ awsnuke_version }}-{{ awsnuke_osarch }}
+awsnuke_dl_url: https://github.com/rebuy-de/{{ awsnuke_app }}/releases/download/v{{ awsnuke_version }}/{{ awsnuke_app }}-v{{ awsnuke_version }}-{{ awsnuke_osarch }}.tar.gz
+awsnuke_app_owner: root
+awsnuke_app_group: root
 awsnuke_bin_path: /usr/local/bin
 awsnuke_file_mode: '0755'
 awsnuke_config_dir: "/etc/{{ awsnuke_app }}"

--- a/tasks/install_debian.yml
+++ b/tasks/install_debian.yml
@@ -1,11 +1,16 @@
 ---
 # tasks file for aws-nuke | Debian/Ubuntu Family
 
-- name: Debian/Ubuntu Family | Downloading archive for {{ awsnuke_app }} {{ awsnuke_version }} to {{ awsnuke_bin_path }}
-  get_url:
-    url: "{{ awsnuke_dl_url }}"
-    dest: "{{ awsnuke_bin_path }}/{{ awsnuke_app }}"
-    mode: "{{ awsnuke_file_mode }}"
+- name: Debian/Ubuntu Family | Downloading and extracting {{ awsnuke_app }} {{ awsnuke_version }}
+  unarchive:
+    src: "{{ awsnuke_dl_url }}"
+    dest: "{{ awsnuke_bin_path }}"
+    owner: "{{ awsnuke_app_owner }}"
+    group: "{{ awsnuke_app_group }}"
+    extra_opts:
+      - --transform
+      - s/{{ awsnuke_app }}\-v{{ awsnuke_version }}\-linux\-amd64/{{ awsnuke_app }}/
+    remote_src: yes
 
 - name: Debian/Ubuntu Family | Setting up {{ awsnuke_app }} config directory {{ awsnuke_config_dir }}
   file:

--- a/tasks/install_el.yml
+++ b/tasks/install_el.yml
@@ -1,11 +1,16 @@
 ---
 # tasks file for aws-nuke | EL Family
 
-- name: EL Family | Downloading archive for {{ awsnuke_app }} {{ awsnuke_version }} to {{ awsnuke_bin_path }}
-  get_url:
-    url: "{{ awsnuke_dl_url }}"
-    dest: "{{ awsnuke_bin_path }}/{{ awsnuke_app }}"
-    mode: "{{ awsnuke_file_mode }}"
+- name: Debian/Ubuntu Family | Downloading and extracting {{ awsnuke_app }} {{ awsnuke_version }}
+  unarchive:
+    src: "{{ awsnuke_dl_url }}"
+    dest: "{{ awsnuke_bin_path }}"
+    owner: "{{ awsnuke_app_owner }}"
+    group: "{{ awsnuke_app_group }}"
+    extra_opts:
+      - --transform
+      - s/{{ awsnuke_app }}\-v{{ awsnuke_version }}\-linux\-amd64/{{ awsnuke_app }}/
+    remote_src: yes
 
 - name: EL Family | Setting up {{ awsnuke_app }} config directory {{ awsnuke_config_dir }}
   file:


### PR DESCRIPTION
* Downloads .tar.gz file for `aws-nuke` as that is now being released.
* Updated Debian/EL family tasks to handle above point.
* README updates