### PR TITLE
Bump aws-nuke to 2.17.0 & variables isolation for os arch

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,8 +6,11 @@ on:
       - 'master'
   push:
     branches:
-      - 'feature/*'
+      - 'feature*'
       - 'feature_*'
+      - 'feature/*'
+      - 'hotfix/*'
+      - 'hotfix*'
       - 'master'
   schedule:
     - cron: '0 10 * * *'
@@ -18,12 +21,12 @@ jobs:
   code_quality:
 
     name: SonarCloud Code Quality Check
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
 
     - name: Checkout source code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
       with:
         path: 'darkwizard242.awsnuke'
         fetch-depth: 0
@@ -31,6 +34,7 @@ jobs:
     - name: SonarCloud Scan
       uses: sonarsource/sonarcloud-github-action@master
       with:
+        projectBaseDir: 'darkwizard242.awsnuke'
         args: >
           -Dsonar.projectVersion=${{ github.ref }}_${{ github.run_number }}
       env:
@@ -41,23 +45,23 @@ jobs:
   build:
 
     name: Build & Test
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       max-parallel: 6
       matrix:
-        IMAGE: [ubuntu-20.04, ubuntu-18.04, ubuntu-16.04, centos-8, centos-7, debian-buster, debian-stretch]
+        IMAGE: [ubuntu-20.04, ubuntu-18.04, centos-8, centos-7, debian-buster, debian-stretch]
 
     steps:
 
     - name: Checkout source code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
       with:
         path: 'darkwizard242.awsnuke'
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.10.0
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.10.0
 
     - name: Update repo cache, install python3-setuptools and required pip modules
       run: |
@@ -66,6 +70,7 @@ jobs:
         pip3 install -U pip wheel ansible molecule[docker] docker ansible-lint flake8 pytest-testinfra
 
     - name: Execute Molecule test of role for ${{ matrix.IMAGE }}
+      working-directory: 'darkwizard242.awsnuke'
       run: DISTRO=${{ matrix.IMAGE }} molecule test
       env:
         PY_COLORS: '1'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,19 +10,19 @@ jobs:
   release:
 
     name: Release
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
 
     - name: Checkout source code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
       with:
         path: 'darkwizard242.awsnuke'
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.10.0
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.10.0
 
     - name: Update repo cache, install python3-setuptools and required pip modules
       run: |
@@ -31,4 +31,5 @@ jobs:
         pip3 install -U pip wheel ansible
 
     - name: Import to Ansible Galaxy.
+      working-directory: 'darkwizard242.awsnuke'
       run: ansible-galaxy role import --api-key ${{ secrets.GALAXY_API_KEY }} ${{ github.repository_owner }} $(echo ${{ github.repository }} | sed 's/.*\///')

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Ali Muhammad
+Copyright (c) 2022 Ali Muhammad
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Available variables are listed below (located in `defaults/main.yml`):
 
 ```yaml
 awsnuke_app: aws-nuke
-awsnuke_version: 2.16.0
+awsnuke_version: 2.17.0
 awsnuke_osarch: linux-amd64
 awsnuke_dl_url: https://github.com/rebuy-de/{{ awsnuke_app }}/releases/download/v{{ awsnuke_version }}/{{ awsnuke_app }}-v{{ awsnuke_version }}-{{ awsnuke_osarch }}.tar.gz
 awsnuke_app_owner: root
@@ -36,25 +36,25 @@ awsnuke_template_dest_group: root
 
 ### Variables table:
 
-Variable                    | Value (default)                                                                                                                                               | Description
---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------
-awsnuke_app                 | aws-nuke                                                                                                                                                      | Defines the app to install i.e. **aws-nuke**
-awsnuke_version             | 2.16.0                                                                                                                                                        | Defined to dynamically fetch the desired version to install. Defaults to: **2.16.0**
-awsnuke_osarch              | linux-amd64                                                                                                                                                   | Defines os architecture. Used for obtaining the correct type of binaries based on OS System Architecture. Defaults to: **linux-amd64**
-awsnuke_dl_url              | <https://github.com/rebuy-de/{{> awsnuke_app }}/releases/download/v{{ awsnuke_version }}/{{ awsnuke_app }}-v{{ awsnuke_version }}-{{ awsnuke_osarch }}.tar.gz | Defines URL to download the awsnuke binary from.
-awsnuke_config_dir_owner    | root                                                                                                                                                          | Owner of aws-nuke binary file.
-awsnuke_config_dir_group    | root                                                                                                                                                          | Group of aws-nuke binary file.
-awsnuke_bin_path            | /usr/local/bin                                                                                                                                                | Defined to dynamically set the appropriate path to store awsnuke binary into. Defaults to (as generally available on any user's PATH): **/usr/local/bin**
-awsnuke_file_mode           | '0755'                                                                                                                                                        | Mode for the binary file of aws-nuke.
-awsnuke_config_dir          | "/etc/{{ awsnuke_app }}"                                                                                                                                      | Defined to create directory to store aws-nuke config file in.
-awsnuke_config_dir_mode     | '0744'                                                                                                                                                        | Permissions for aws-nuke config directory.
-awsnuke_config_dir_owner    | root                                                                                                                                                          | Owner of aws-nuke config directory.
-awsnuke_config_dir_group    | root                                                                                                                                                          | Group of aws-nuke config directory.
-awsnuke_template_source     | aws-nuke-config.yml.j2                                                                                                                                        | Source config template file to utilize.
-awsnuke_template_dest       | aws-nuke-config.yml                                                                                                                                           | Filename as to be placed in the configuration directory as for aws-nuke.
-awsnuke_template_dest_mode  | '0744'                                                                                                                                                        | Permission of aws-nuke configuration file.
-awsnuke_template_dest_owner | root                                                                                                                                                          | Owner of aws-nuke configuration file.
-awsnuke_template_dest_group | root                                                                                                                                                          | Group of aws-nuke configuration file.
+Variable                    | Description
+--------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------
+awsnuke_app                 | Defines the app to install i.e. **aws-nuke**
+awsnuke_version             | Defined to dynamically fetch the desired version to install. Defaults to: **2.17.0**
+awsnuke_osarch              | Defines os architecture. Used for obtaining the correct type of binaries based on OS System Architecture. Defaults to: **linux-amd64**
+awsnuke_dl_url              | Defines URL to download the awsnuke binary from.
+awsnuke_config_dir_owner    | Owner of aws-nuke binary file.
+awsnuke_config_dir_group    | Group of aws-nuke binary file.
+awsnuke_bin_path            | Defined to dynamically set the appropriate path to store awsnuke binary into. Defaults to (as generally available on any user's PATH): **/usr/local/bin**
+awsnuke_file_mode           | Mode for the binary file of aws-nuke.
+awsnuke_config_dir          | Defined to create directory to store aws-nuke config file in.
+awsnuke_config_dir_mode     | Permissions for aws-nuke config directory.
+awsnuke_config_dir_owner    | Owner of aws-nuke config directory.
+awsnuke_config_dir_group    | Group of aws-nuke config directory.
+awsnuke_template_source     | Source config template file to utilize.
+awsnuke_template_dest       | Filename as to be placed in the configuration directory as for aws-nuke.
+awsnuke_template_dest_mode  | Permission of aws-nuke configuration file.
+awsnuke_template_dest_owner | Owner of aws-nuke configuration file.
+awsnuke_template_dest_group | Group of aws-nuke configuration file.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ Available variables are listed below (located in `defaults/main.yml`):
 ```yaml
 awsnuke_app: aws-nuke
 awsnuke_version: 2.17.0
-awsnuke_osarch: linux-amd64
-awsnuke_dl_url: https://github.com/rebuy-de/{{ awsnuke_app }}/releases/download/v{{ awsnuke_version }}/{{ awsnuke_app }}-v{{ awsnuke_version }}-{{ awsnuke_osarch }}.tar.gz
+awsnuke_os: linux
+awsnuke_arch: amd64
+awsnuke_dl_url: https://github.com/rebuy-de/{{ awsnuke_app }}/releases/download/v{{ awsnuke_version }}/{{ awsnuke_app }}-v{{ awsnuke_version }}-{{ awsnuke_os }}-{{ awsnuke_arch }}.tar.gz
 awsnuke_app_owner: root
 awsnuke_app_group: root
 awsnuke_bin_path: /usr/local/bin
@@ -40,7 +41,8 @@ Variable                    | Description
 --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------
 awsnuke_app                 | Defines the app to install i.e. **aws-nuke**
 awsnuke_version             | Defined to dynamically fetch the desired version to install. Defaults to: **2.17.0**
-awsnuke_osarch              | Defines os architecture. Used for obtaining the correct type of binaries based on OS System Architecture. Defaults to: **linux-amd64**
+awsvault_os                 | Defines os type. Used for obtaining the correct type of binaries based on OS type. Defaults to: **linux**
+awsvault_arch               | Defines os architecture. Used to set the correct type of binaries based on OS System Architecture. Defaults to: **amd64**
 awsnuke_dl_url              | Defines URL to download the awsnuke binary from.
 awsnuke_config_dir_owner    | Owner of aws-nuke binary file.
 awsnuke_config_dir_group    | Group of aws-nuke binary file.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,9 +2,10 @@
 # defaults file for aws-nuke
 
 awsnuke_app: aws-nuke
-awsnuke_version: 2.16.0
-awsnuke_osarch: linux-amd64
-awsnuke_dl_url: https://github.com/rebuy-de/{{ awsnuke_app }}/releases/download/v{{ awsnuke_version }}/{{ awsnuke_app }}-v{{ awsnuke_version }}-{{ awsnuke_osarch }}.tar.gz
+awsnuke_version: 2.17.0
+awsnuke_os: linux
+awsnuke_arch: amd64
+awsnuke_dl_url: https://github.com/rebuy-de/{{ awsnuke_app }}/releases/download/v{{ awsnuke_version }}/{{ awsnuke_app }}-v{{ awsnuke_version }}-{{ awsnuke_os }}-{{ awsnuke_arch }}.tar.gz
 awsnuke_app_owner: root
 awsnuke_app_group: root
 awsnuke_bin_path: /usr/local/bin

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -8,8 +8,8 @@ lint: |
     ansible-lint
     flake8
 platforms:
-  - name: ${DISTRO:-ubuntu-18.04}
-    image: "darkwizard242/ansible:${DISTRO:-ubuntu-18.04}"
+  - name: ${DISTRO:-ubuntu-20.04}
+    image: "darkwizard242/ansible:${DISTRO:-ubuntu-20.04}"
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     pre_build_image: true

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,6 +2,7 @@ sonar.projectKey=ansible-role-awsnuke
 sonar.organization=tech-overlord-github
 sonar.projectName=ansible-role-awsnuke
 sonar.coverage.exclusions=**/**
+sonar.python.version=3
 #sonar.projectVersion=$TRAVIS_JOB_ID
 
 # =====================================================

--- a/tasks/install_debian.yml
+++ b/tasks/install_debian.yml
@@ -9,7 +9,7 @@
     group: "{{ awsnuke_app_group }}"
     extra_opts:
       - --transform
-      - s/{{ awsnuke_app }}\-v{{ awsnuke_version }}\-linux\-amd64/{{ awsnuke_app }}/
+      - s/{{ awsnuke_app }}\-v{{ awsnuke_version }}\-{{ awsnuke_os }}\-{{ awsnuke_arch }}/{{ awsnuke_app }}/
     remote_src: yes
 
 - name: Debian/Ubuntu Family | Setting up {{ awsnuke_app }} config directory {{ awsnuke_config_dir }}

--- a/tasks/install_el.yml
+++ b/tasks/install_el.yml
@@ -9,7 +9,7 @@
     group: "{{ awsnuke_app_group }}"
     extra_opts:
       - --transform
-      - s/{{ awsnuke_app }}\-v{{ awsnuke_version }}\-linux\-amd64/{{ awsnuke_app }}/
+      - s/{{ awsnuke_app }}\-v{{ awsnuke_version }}\-{{ awsnuke_os }}\-{{ awsnuke_arch }}/{{ awsnuke_app }}/
     remote_src: yes
 
 - name: EL Family | Setting up {{ awsnuke_app }} config directory {{ awsnuke_config_dir }}


### PR DESCRIPTION
- Utilize github actions/checkout@v2 and Python 3.10.0 in build-and-test workflow
- Utilize github actions/checkout@v2 and Python 3.10.0 in release workflow
- Separate out variables for OS and Arch
- Enhance extraction transformation
- Set default image to be used by molecule as Ubuntu 20.04
- Bump `aws-nuke` to 2.17.0